### PR TITLE
FIX #9: Stop JPAModelGenCompile to interfere with Java compile

### DIFF
--- a/jpamodelgen-plugin/src/main/groovy/com/github/iboyko/gradle/plugins/jpamodelgen/JpaModelgenPlugin.groovy
+++ b/jpamodelgen-plugin/src/main/groovy/com/github/iboyko/gradle/plugins/jpamodelgen/JpaModelgenPlugin.groovy
@@ -35,7 +35,7 @@ import com.github.iboyko.gradle.plugins.jpamodelgen.tasks.*
  * classes will be generated, so that they can be ignored from SCM commits. Per default, this will
  * be {@link JpaModelgenPluginExtension#DEFAULT_JPAMODELGEN_SOURCES_DIR}.
  * <br/><br/>
- * 
+ *
  *
  * @author Illya Boyko
  * @since 1.0.0
@@ -45,8 +45,9 @@ class JpaModelgenPlugin implements Plugin<Project> {
     public static final String TASK_GROUP = "JpaModelgen tasks"
 
     private static final Logger LOG = Logging.getLogger(JpaModelgenPlugin.class)
+	public static final String CONFIGURATION_NAME = "jpaModelgen"
 
-    @Override
+	@Override
     void apply(final Project project) {
 	LOG.info("Applying JpaModelgen plugin")
 
@@ -55,7 +56,7 @@ class JpaModelgenPlugin implements Plugin<Project> {
 	    return;
 	}
 
-	LOG.info("Applying JpaModelgen plugin")
+	LOG.info("Applying Java plugin")
 
 	// apply core 'java' plugin if not present to make 'sourceSets' available
 	if (!project.plugins.hasPlugin(JavaPlugin.class)) {
@@ -71,6 +72,10 @@ class JpaModelgenPlugin implements Plugin<Project> {
 
 	// make 'clean' depend cleaning jpaModelgen sources
 	project.tasks.clean.dependsOn project.tasks.cleanJpaModelgenSourcesDir
+
+
+	LOG.info("Create configuration 'jpaModelgen'")
+	project.configurations.create(CONFIGURATION_NAME)
 
 	project.task(type: JpaModelgenCompile, "compileJpaModelgen")
 	project.tasks.compileJpaModelgen.dependsOn project.tasks.initJpaModelgenSourcesDir
@@ -90,9 +95,9 @@ class JpaModelgenPlugin implements Plugin<Project> {
     }
 
     private void addLibrary(Project project) {
-	def library = project.extensions.jpaModelgen.library
-	LOG.info("JpaModelgen library: {}", library)
-	project.dependencies { compile library }
+	def library = project.extensions[JpaModelgenPluginExtension.NAME].library
+	LOG.info("Add to configuration 'jpaModelgen' library: {}", library)
+	project.dependencies.add (JpaModelgenPlugin.CONFIGURATION_NAME, library)
     }
 
     private void addSourceSet(Project project, File sourcesDir) {

--- a/jpamodelgen-plugin/src/main/groovy/com/github/iboyko/gradle/plugins/jpamodelgen/tasks/InitJpaModelgenSourcesDir.groovy
+++ b/jpamodelgen-plugin/src/main/groovy/com/github/iboyko/gradle/plugins/jpamodelgen/tasks/InitJpaModelgenSourcesDir.groovy
@@ -39,7 +39,7 @@ class InitJpaModelgenSourcesDir extends DefaultTask {
 
     @TaskAction
     def createSourceFolders() {
-	logger.info("Init JpaModelgen source dir" + project.jpaModelgen.jpaModelgenSourcesDir)
+	logger.info("Init JpaModelgen source dir " + project.jpaModelgen.jpaModelgenSourcesDir)
 	project.file(project.jpaModelgen.jpaModelgenSourcesDir).mkdirs()
     }
 }

--- a/jpamodelgen-plugin/src/main/groovy/com/github/iboyko/gradle/plugins/jpamodelgen/tasks/JpaModelgenCompile.groovy
+++ b/jpamodelgen-plugin/src/main/groovy/com/github/iboyko/gradle/plugins/jpamodelgen/tasks/JpaModelgenCompile.groovy
@@ -28,7 +28,7 @@ class JpaModelgenCompile extends JavaCompile {
     JpaModelgenCompile() {
 
 	setSource(project.sourceSets.main.java)
-	setClasspath(project.configurations.compileClasspath)
+	setClasspath(project.configurations.compile + project.configurations.jpaModelgen)
 
 	project.afterEvaluate {
 	    File file = project.file(project.jpaModelgen.jpaModelgenSourcesDir)

--- a/jpamodelgen-plugin/src/test/groovy/com/github/iboyko/gradle/plugins/jpamodelgen/JpaModelgenPluginTest.groovy
+++ b/jpamodelgen-plugin/src/test/groovy/com/github/iboyko/gradle/plugins/jpamodelgen/JpaModelgenPluginTest.groovy
@@ -57,6 +57,11 @@ class JpaModelgenPluginTest {
     }
 
     @Test
+    public void testPluginRegistersJpaModelgenConfiguration() {
+        assertThat(project.configurations.jpaModelgen, notNullValue())
+    }
+
+    @Test
     public void testPluginRegistersJpaModelgenExtensions() {
 	assertThat(project.extensions.jpaModelgen, notNullValue())
     }
@@ -82,7 +87,7 @@ class JpaModelgenPluginTest {
     public void testAfterEvaluate() {
 	project.evaluate()
 
-	DefaultExternalModuleDependency lib = project.configurations.compile.dependencies
+	DefaultExternalModuleDependency lib = project.configurations.jpaModelgen.dependencies
 		.getAt(0) as DefaultExternalModuleDependency
 
 	String id = lib.group + ":" + lib.name + ":" + lib.version

--- a/samples/jpamodelgen-sample/build.gradle
+++ b/samples/jpamodelgen-sample/build.gradle
@@ -35,5 +35,3 @@ compileJpaModelgen {
 dependencies {
     compile 'org.hibernate:hibernate-entitymanager:4.3.8.Final'
 }
-
-compileJava.options.compilerArgs += ["-proc:none"]


### PR DESCRIPTION

* This ensures all other processors, like lombok, can run normally during compile.
* Run JPAModelGenCompile with an own configuration + classpath  to ensure, it doesn’t run again with compileJava.
* The ‘compileJava’ task hasn’t the lib ‘hibernate-jpamodelgen’ on its class path anymore and can run normally again.
* This also allows to drop the Workaround of >compileJava.options.compilerArgs += ["-proc:none”]<
* There is still some handcrafting needed to get intelliJ to understand the package structure.